### PR TITLE
export 'AssetsPath'

### DIFF
--- a/Test/Tasty/Runners/Html.hs
+++ b/Test/Tasty/Runners/Html.hs
@@ -7,6 +7,7 @@
 module Test.Tasty.Runners.Html
   ( HtmlPath(..)
   , htmlRunner
+  , AssetsPath(..)
   ) where
 
 import Control.Applicative (Const(..), (<$))


### PR DESCRIPTION
This would allow us to use this option directly in the code, and we could switch to the upstream version instead of our fork :-)
